### PR TITLE
[ISSUE #32] add check_message_type to publishing setting.

### DIFF
--- a/apache/rocketmq/v2/service.proto
+++ b/apache/rocketmq/v2/service.proto
@@ -194,9 +194,9 @@ message Publishing {
   // client-side check validation.
   int32 max_body_size = 3;
 
-  // When `check_message_type` flag set `false`, no need to check message's type
+  // When `validate_message_type` flag set `false`, no need to validate message's type
   // with messageQueue's `accept_message_types` before publising.
-  bool check_message_type = 4;
+  bool validate_message_type = 4;
 }
 
 message Subscription {

--- a/apache/rocketmq/v2/service.proto
+++ b/apache/rocketmq/v2/service.proto
@@ -196,7 +196,7 @@ message Publishing {
 
   // When `check_message_type` flag set `false`, no need to check message's type
   // with messageQueue's `accept_message_types` before publising.
-  optional bool check_message_type = 4;
+  bool check_message_type = 4;
 }
 
 message Subscription {

--- a/apache/rocketmq/v2/service.proto
+++ b/apache/rocketmq/v2/service.proto
@@ -193,6 +193,10 @@ message Publishing {
   // reject the request. As a result, it is advisable that Producer performs
   // client-side check validation.
   int32 max_body_size = 3;
+
+  // When `check_message_type` flag set `false`, no need to check message's type
+  // with messageQueue's `accept_message_types` before publising.
+  optional bool check_message_type = 4;
 }
 
 message Subscription {


### PR DESCRIPTION
add check_message_type to publishing setting,  no need to check message's type when this flag set false from server.