### PR TITLE
Add status code: multiple results

### DIFF
--- a/apache/rocketmq/v2/definition.proto
+++ b/apache/rocketmq/v2/definition.proto
@@ -388,6 +388,9 @@ enum Code {
   // Client type could not be recognized.
   UNRECOGNIZED_CLIENT_TYPE = 32;
 
+  // Return different results for entries in composite request.
+  MULTIPLE_RESULTS = 33;
+
   // Code indicates that the server encountered an unexpected condition
   // that prevented it from fulfilling the request.
   // This error response is a generic "catch-all" response.


### PR DESCRIPTION
Since we add entries for `SendMessageResponse`, `status` in `SendMessageResponse` may be ambiguous. It's better to add a new status code.