### PR TITLE
Add metric endpoints

### DIFF
--- a/apache/rocketmq/v2/service.proto
+++ b/apache/rocketmq/v2/service.proto
@@ -234,6 +234,13 @@ message Subscription {
   optional google.protobuf.Duration long_polling_timeout = 5;
 }
 
+message Metric {
+  // Indicates that if client should export local metrics to server.
+  bool on = 1;
+  // The endpoint that client metrics should be exported to, which is required if the switch is on.
+  optional Endpoints metric_endpoints = 2;
+}
+
 message Settings {
   // Configurations for all clients.
   optional ClientType client_type = 1;
@@ -263,6 +270,8 @@ message Settings {
 
   // User agent details
   UA user_agent = 7;
+
+  Metric metric = 8;
 }
 
 message TelemetryCommand {


### PR DESCRIPTION
Since we have the need to collect metrics from client, the metric endpoint should be included in the settings.