### PR TITLE
build(deps): Update gRPC Java dependency version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,3 +25,6 @@ build --action_env=CXX
 build --action_env=LD_LIBRARY_PATH
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
+
+build --cxxopt='-std=c++17'
+build:host --cxxopt='-std=c++17'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - name: Setup Bazel
         run: |
           sudo apt-get -qq install npm
           sudo npm install -g @bazel/bazelisk
-      - name: Use Bazel
+      - name: Bazel Help
         if: matrix.os != 'windows'
         run: bazel -h
-      - name: Compile All Targets
-        run: bazel build //...
+      - name: Build with Bazel
+        run: bazel build //... -s

--- a/deps.bzl
+++ b/deps.bzl
@@ -38,8 +38,9 @@ def github_archive(name, org, repo, ref, sha256):
             name = name,
             strip_prefix = repo + "-" + stripRef,
             urls = [
-                "https://mirror.bazel.build/github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
-                "https://github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
+                # "https://mirror.bazel.build/github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
+                # "https://github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
+                "https://github.com/%s/%s/archive/refs/tags/%s.tar.gz" % (org, repo, ref)
             ],
             sha256 = sha256,
         )
@@ -48,6 +49,6 @@ def io_grpc_grpc_java(**kwargs):
     """grpc java plugin and jars
     """
     name = "io_grpc_grpc_java"
-    ref = get_ref(name, "8eff2630828a7ec6f4980b5b46f30f875070a4e4", kwargs)  # v1.19.0 and changes up to PR #5456
-    sha256 = get_sha256(name, "f0e17fb16a404ba473429144481221e2c970c65596f65129002af3c73dcfe141", kwargs)
+    ref = get_ref(name, "v1.45.0", kwargs)  # v1.19.0 and changes up to PR #5456
+    sha256 = get_sha256(name, "83a3e094be70978cd843778a3214268714e077343fd9a5baacad31dd420304c3", kwargs)
     github_archive(name, "grpc", "grpc-java", ref, sha256)


### PR DESCRIPTION
- Upgraded gRPC Java version from 1.19.0 to 1.45.0
- Updated the corresponding SHA256 checksum