### PR TITLE
build(bazel): Compile using the specified versions of G++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,8 +20,8 @@ build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --enable_platform_specific_config
 
 # Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
-build --action_env=CC
-build --action_env=CXX
+build --action_env=CC=gcc-11
+build --action_env=CXX=g++-11
 build --action_env=LD_LIBRARY_PATH
 build --action_env=LLVM_CONFIG
 build --action_env=PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       
       - name: Setup Bazel
         run: |
-          sudo apt-get -qq install npm
+          sudo apt-get -qq install npm gcc-11 g++-11
           sudo npm install -g @bazel/bazelisk
       - name: Use Bazel
         if: matrix.os != 'windows'

--- a/deps.bzl
+++ b/deps.bzl
@@ -38,7 +38,6 @@ def github_archive(name, org, repo, ref, sha256):
             name = name,
             strip_prefix = repo + "-" + stripRef,
             urls = [
-                "https://mirror.bazel.build/github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
                 "https://github.com/%s/%s/archive/%s.tar.gz" % (org, repo, ref),
             ],
             sha256 = sha256,


### PR DESCRIPTION
build(bazel): Compile using the specified versions of G++. In Ubuntu-24, gcc-13 is used by default. Some absl syntax can be compiled normally in gcc-11 but cannot be compiled in gcc-13.