### PR TITLE
feat: add extension info to AdminSendMessageRequest

### DIFF
--- a/apache/rocketmq/v2/admin.proto
+++ b/apache/rocketmq/v2/admin.proto
@@ -383,6 +383,10 @@ message AdminSendMessageRequest {
   map<string, string> user_properties = 5;
   // System properties of the message.
   optional SystemProperties system_properties = 6;
+  // Request-scoped extension information. Unknown entries should be ignored.
+  // Known keys:
+  // - protocol_type: Protocol used by the original producer (REMOTING or GRPC_V2).
+  map<string, string> ext_info = 7;
 }
 
 message AdminSendMessageResponse {


### PR DESCRIPTION
## Motivation

`AdminSendMessageRequest` currently has no request-scoped channel for carrying routing hints. FIFO admin sends need to select queues with the hash algorithm associated with the original producer protocol; using a different selector can route the same message group or sharding key to a different queue or broker.

This metadata controls how the Admin RPC is handled and should not be mixed into stored message properties. See #114 for the design discussion.

## Changes

- Add `map<string, string> ext_info = 7` to `AdminSendMessageRequest`.
- Document `protocol_type` as the initial key, with `REMOTING` and `GRPC_V2` values.
- Specify that unknown extension entries should be ignored.

## Compatibility

The change is wire-compatible in both rolling-upgrade directions. Old servers ignore field 7; new servers receive an empty map from old clients and can apply their default behavior.

## Verification

- Compiled `admin.proto` and its imports into a descriptor set with `protoc 3.21.1`.
- Ran `git diff --check`.

Closes #114