### PR TITLE
feat: add deployment and lite topic fields to Admin service

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 9. Enums field number = 0 is redefined to meet requirement [Each enum value should end with a semicolon, not a comma. Prefer prefixing enum values instead of surrounding them in an enclosing message. The zero value enum should have the suffix UNSPECIFIED.](https://developers.google.com/protocol-buffers/docs/style)
 10. Nested enumerations are externalized due to the same guide item as above.
 11. Expanded the Admin service with control-plane RPCs for topic/subscription/consumer administration and diagnostics (DescribeTopicStatus, ListSubscription, DescribeSubscription, DeleteSubscription, DescribeGroupAccumulation, ListConsumerConnection, ResetGroupOffset, QueryMessage, PrintThreadStackTrace, VerifyMessage, AdminSendMessage, GetConsumerRunningInfo, GetTopicRoute, QueryTimeSpan, GetProxyRuntimeStats).
+12. Admin control-plane requests carry an optional `deployment_name` to address a single deployment in multi-tenant environments, and the lite topic dimension is exposed through `lite_topic` / `liteTopic` / `lite_topic_accumulation` plus the `LITE_SELECTIVE` consumption model. Admin field numbers are assigned so that the definitions stay wire compatible with Admin services already deployed against these RPCs.
 
 Remaining Issues:
 How server publishes conf and conf changes to clients.

--- a/apache/rocketmq/v2/admin.proto
+++ b/apache/rocketmq/v2/admin.proto
@@ -50,7 +50,10 @@ message ChangeLogLevelResponse {
 
 // Request the status and metadata of a topic.
 message DescribeTopicStatusRequest {
-  Resource topic = 1;
+  // Identifies the target deployment (instance) in multi-tenant environments
+  // where a single endpoint serves several isolated deployments.
+  optional string deployment_name = 1;
+  Resource topic = 2;
 }
 
 message DescribeTopicStatusResponse {
@@ -73,8 +76,10 @@ message DescribeTopicStatusResponse {
 // List subscription relationships filtered by topic and/or group.
 // At least one of the two filters is expected to be set.
 message ListSubscriptionRequest {
-  optional Resource topic = 1;
-  optional Resource group = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  optional Resource topic = 2;
+  optional Resource group = 3;
 }
 
 // A single subscription relationship between a group and a topic.
@@ -107,8 +112,10 @@ message ListSubscriptionResponse {
 // ListSubscription, this returns the subscription reported by each individual
 // client, which helps diagnose inconsistent subscriptions within a group.
 message DescribeSubscriptionRequest {
-  optional Resource topic = 1;
-  optional Resource group = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  optional Resource topic = 2;
+  optional Resource group = 3;
 }
 
 message DescribeSubscriptionResponse {
@@ -124,11 +131,13 @@ message DescribeSubscriptionResponse {
 
 // Delete a subscription relationship between a group and a topic.
 message DeleteSubscriptionRequest {
-  Resource topic = 1;
-  Resource group = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource topic = 2;
+  Resource group = 3;
 
   // The filter expression that identifies the subscription to delete.
-  FilterExpression expression = 3;
+  FilterExpression expression = 4;
 }
 
 message DeleteSubscriptionResponse {
@@ -164,6 +173,10 @@ enum MessageModel {
 
   // Every consumer within the group receives the full stream of messages.
   BROADCASTING = 2;
+
+  // Consumers of the group selectively subscribe to individual lite topics
+  // that are multiplexed onto a shared physical topic.
+  LITE_SELECTIVE = 3;
 }
 
 // A message queue together with the process queue snapshot held by a consumer.
@@ -218,11 +231,16 @@ message ConsumerRunningInfo {
 
 // Query the message accumulation (lag) of a consumer group.
 message DescribeGroupAccumulationRequest {
-  Resource group = 1;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource group = 2;
 
   // Optional set of topics to break the accumulation down by. When empty, the
   // aggregated accumulation of the whole group is returned.
-  repeated Resource topics = 2;
+  repeated Resource topics = 3;
+
+  // Restrict the query to a single lite topic multiplexed onto the topics above.
+  optional string lite_topic = 4;
 }
 
 message DescribeGroupAccumulationResponse {
@@ -251,12 +269,17 @@ message DescribeGroupAccumulationResponse {
 
   // Per-topic accumulation, keyed by topic name.
   map<string, GroupAccumulation> topic_accumulation = 3;
+
+  // Per-lite-topic accumulation, keyed by lite topic name.
+  map<string, GroupAccumulation> lite_topic_accumulation = 4;
 }
 
 // Query the time span of messages consumed by a group across its topics.
 message QueryTimeSpanRequest {
-  Resource group = 1;
-  repeated Resource topics = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource group = 2;
+  repeated Resource topics = 3;
 }
 
 message QueryTimeSpanResponse {
@@ -283,10 +306,15 @@ message QueryTimeSpanResponse {
 
 // List the online consumer connections of a group.
 message ListConsumerConnectionRequest {
-  Resource group = 1;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource group = 2;
 
   // Optional topic filter.
-  optional Resource topic = 2;
+  optional Resource topic = 3;
+
+  // Optional lite topic filter, multiplexed onto the topic above.
+  optional string liteTopic = 4;
 }
 
 message ListConsumerConnectionResponse {
@@ -296,11 +324,13 @@ message ListConsumerConnectionResponse {
 
 // Reset the consume offset of a group on a topic to the given timestamp.
 message ResetGroupOffsetRequest {
-  Resource group = 1;
-  Resource topic = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource group = 2;
+  Resource topic = 3;
 
   // Messages stored at or after this timestamp will be re-consumed.
-  google.protobuf.Timestamp reset_timestamp = 3;
+  google.protobuf.Timestamp reset_timestamp = 4;
 }
 
 message ResetGroupOffsetResponse {
@@ -309,32 +339,37 @@ message ResetGroupOffsetResponse {
 
 // Query messages of a topic by id, key or subscription within a time range.
 message ListMessageRequest {
-  Resource topic = 1;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource topic = 2;
 
   // Maximum number of messages to return.
-  int32 max_message_nums = 2;
+  int32 max_message_nums = 3;
 
   // Time range (inclusive begin, inclusive end) to scan.
-  google.protobuf.Timestamp begin_timestamp = 3;
-  google.protobuf.Timestamp end_timestamp = 4;
+  google.protobuf.Timestamp begin_timestamp = 4;
+  google.protobuf.Timestamp end_timestamp = 5;
 
   // The key used to locate messages. Exactly one should be set.
   oneof search_key {
-    string message_id = 5;
-    string message_key = 6;
-    string subscription = 7;
+    string message_id = 6;
+    string message_key = 7;
+    string subscription = 8;
+
+    // Scan every message belonging to the given lite topic.
+    string lite_topic = 14;
   }
 
   // Opaque cursor for scroll-style pagination, echoed from a previous response.
-  optional string scroll_id = 8;
+  optional string scroll_id = 9;
 
   // Page-style pagination parameters.
-  optional int32 page_num = 9;
-  optional int32 page_size = 10;
+  optional int32 page_num = 10;
+  optional int32 page_size = 11;
 
   // Restrict the query to a specific broker and queue.
-  optional string broker_name = 11;
-  optional int32 queue_id = 12;
+  optional string broker_name = 12;
+  optional int32 queue_id = 13;
 }
 
 message ListMessageResponse {
@@ -347,8 +382,10 @@ message ListMessageResponse {
 
 // Print the thread stack trace of a specific client, for diagnostics.
 message PrintThreadStackTraceRequest {
-  string client_id = 1;
-  Resource group = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  string client_id = 2;
+  Resource group = 3;
 }
 
 message PrintThreadStackTraceResponse {
@@ -359,10 +396,12 @@ message PrintThreadStackTraceResponse {
 // Ask a specific client to consume the given message once, to verify that the
 // consumer logic works as expected.
 message VerifyMessageRequest {
-  string client_id = 1;
-  Resource group = 2;
-  Resource topic = 3;
-  string message_id = 4;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  string client_id = 2;
+  Resource group = 3;
+  Resource topic = 4;
+  string message_id = 5;
 }
 
 message VerifyMessageResponse {
@@ -372,21 +411,23 @@ message VerifyMessageResponse {
 // Send a message from the admin side, typically used to send a test message
 // from a console.
 message AdminSendMessageRequest {
-  Resource topic = 1;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource topic = 2;
   // Tag, which is optional.
-  optional string tag = 2;
+  optional string tag = 3;
   // Message key
-  optional string key = 3;
+  optional string key = 4;
   // Message body
-  bytes body = 4;
+  bytes body = 5;
   // User-defined properties of the message.
-  map<string, string> user_properties = 5;
+  map<string, string> user_properties = 6;
   // System properties of the message.
-  optional SystemProperties system_properties = 6;
+  optional SystemProperties system_properties = 7;
   // Request-scoped extension information. Unknown entries should be ignored.
   // Known keys:
   // - protocol_type: Protocol used by the original producer (REMOTING or GRPC_V2).
-  map<string, string> ext_info = 7;
+  map<string, string> ext_info = 8;
 }
 
 message AdminSendMessageResponse {
@@ -398,8 +439,10 @@ message AdminSendMessageResponse {
 
 // Fetch the aggregated running information of a specific consumer client.
 message GetConsumerRunningInfoRequest {
-  Resource group = 1;
-  string client_id = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource group = 2;
+  string client_id = 3;
 }
 
 message GetConsumerRunningInfoResponse {
@@ -415,17 +458,19 @@ message GetTopicRouteRequest {
     INTERNET = 1;
     INTRANET = 2;
   }
-  Resource topic = 1;
-  NetworkType network_type = 2;
+  // Identifies the target deployment (instance) in multi-tenant environments.
+  optional string deployment_name = 1;
+  Resource topic = 2;
+  NetworkType network_type = 3;
 
   // Protocol type the client speaks, e.g. "grpc" or "remoting".
-  string protocol_type = 3;
+  string protocol_type = 4;
 
   // Whether the request comes from a streaming client.
-  bool stream_request_type = 4;
+  bool stream_request_type = 5;
 
   // Address of the requesting client.
-  string client_address = 5;
+  string client_address = 6;
 }
 
 message GetTopicRouteResponse {


### PR DESCRIPTION
## Summary

Follow-up to #113 and #115, addressing review feedback on the Admin control-plane definitions.

- Add an optional `deployment_name` to the fourteen Admin requests, so a single endpoint can address one of several isolated deployments in a multi-tenant setup.
- Expose the lite topic dimension: `lite_topic` on `DescribeGroupAccumulationRequest` and in the `ListMessageRequest.search_key` oneof, `liteTopic` on `ListConsumerConnectionRequest`, and `lite_topic_accumulation` on `DescribeGroupAccumulationResponse`.
- Add the `LITE_SELECTIVE` consumption model to `MessageModel`, for groups whose consumers selectively subscribe to individual lite topics multiplexed onto a shared physical topic.
- Move `AdminSendMessageRequest.ext_info` from field 7 to 8, keeping `system_properties` at 7.

## On the field number changes

The reassignment of field numbers is intentional and safe: **the Admin control-plane RPCs have not been released yet.** The latest tag is `v2.1.2`, which predates #113, so no published artifact carries these definitions and no consumer can depend on the current numbering. Renumbering now is free; doing it after a release would be a breaking change.

The numbers chosen here are the ones the Admin services already deployed against these RPCs use on the wire, so this alignment also keeps existing deployments interoperable.

`definition.proto` and `service.proto` are unchanged.

## Verification

- `protoc 3.19.4` compiles all three files with `--java_out` cleanly.
- Compared the generated `FileDescriptorSet` against the layout used by existing Admin deployments: 379 fields in common, **0 conflicts** where the same field number carries a different type or label. Messages, enums, enum values and RPC signatures all match; no definition is missing.

## Test plan

- [x] `protoc --java_out` succeeds for `admin.proto`, `definition.proto`, `service.proto`
- [x] Descriptor-level comparison shows no field number/type/label conflict
- [ ] CI build on this PR